### PR TITLE
Add FastAPI RAG example

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,20 @@ The following table maps the roles used by the application to their respective f
 
 ![image](/docs/images/E2E_multimodal_flow.png)
 
+## Simple FastAPI example
+
+For a minimal RAG demo using FastAPI, run:
+
+```bash
+uvicorn src.backend.fastapi_rag_demo:app --reload
+```
+
+The [`fastapi_rag_demo.py`](src/backend/fastapi_rag_demo.py) script connects to
+your Azure AI Search index and Azure OpenAI deployment using the environment
+variables `SEARCH_SERVICE_ENDPOINT`, `SEARCH_INDEX_NAME`,
+`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT` and
+`AZURE_OPENAI_MODEL_NAME`.
+
 ## Troubleshooting
 - What is the region availability for Azure OpenAI service?  
   Please visit [available regions](https://learn.microsoft.com/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#global-standard-model-availability)

--- a/src/backend/fastapi_rag_demo.py
+++ b/src/backend/fastapi_rag_demo.py
@@ -1,0 +1,59 @@
+from typing import List
+import os
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
+from azure.search.documents.aio import SearchClient
+from openai import AsyncAzureOpenAI
+
+
+app = FastAPI()
+
+# Initialize Azure credentials and clients
+credential = DefaultAzureCredential()
+token_provider = get_bearer_token_provider(
+    credential, "https://cognitiveservices.azure.com/.default"
+)
+
+search_client = SearchClient(
+    endpoint=os.environ["SEARCH_SERVICE_ENDPOINT"],
+    index_name=os.environ["SEARCH_INDEX_NAME"],
+    credential=credential,
+)
+
+openai_client = AsyncAzureOpenAI(
+    api_version="2024-08-01-preview",
+    azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+    azure_ad_token_provider=token_provider,
+)
+openai_model = os.environ["AZURE_OPENAI_MODEL_NAME"]
+openai_deployment = os.environ["AZURE_OPENAI_DEPLOYMENT"]
+
+
+class Question(BaseModel):
+    text: str
+
+
+@app.post("/ask")
+async def ask_question(question: Question):
+    """Query Azure AI Search and generate an answer with Azure OpenAI."""
+    # Retrieve top documents from the search index
+    results = search_client.search(question.text, top=3)
+    docs: List[str] = []
+    async for doc in results:
+        # 'content' is the text field created by the indexing process
+        docs.append(doc.get("content", ""))
+
+    context = "\n".join(docs)
+    prompt = f"{context}\n\nQuestion: {question.text}\nAnswer:"
+
+    completion = await openai_client.chat.completions.create(
+        model=openai_model,
+        deployment_id=openai_deployment,
+        messages=[{"role": "user", "content": prompt}],
+    )
+
+    answer = completion.choices[0].message.content
+    return {"answer": answer, "sources": docs}

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -15,3 +15,5 @@ azure-storage-blob == 12.24.0
 --extra-index-url https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/
 azure-search-documents==11.6.0a20250505003
 pyjwt
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add simple FastAPI demo using Azure Search index and Azure OpenAI
- document running the demo
- include FastAPI and uvicorn in requirements

## Testing
- `python3 -m py_compile src/backend/fastapi_rag_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_684828b34634832aa37df94e76b10dae