### PR TITLE
Enable CORS support for API servers

### DIFF
--- a/legal_nlp_server.py
+++ b/legal_nlp_server.py
@@ -2,6 +2,7 @@ import os
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse
+from fastapi.middleware.cors import CORSMiddleware
 from openai import OpenAI
 from pydantic import BaseModel
 
@@ -9,6 +10,13 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 openai_client = OpenAI(api_key=OPENAI_API_KEY) if OPENAI_API_KEY else None
 
 app = FastAPI(title="Litigator Legal NLP")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.on_event("startup")

--- a/legal_research_server.py
+++ b/legal_research_server.py
@@ -2,6 +2,7 @@ import os
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import FileResponse
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from app.services.rag_service import RagService
@@ -13,6 +14,13 @@ if not OPENAI_API_KEY:
     RagService  # noqa: F401
 
 app = FastAPI(title="Litigator Legal Research MCP")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.on_event("startup")

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from fastapi import FastAPI, Request
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
 from rich.logging import RichHandler
 from openai import AsyncAzureOpenAI
 from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
@@ -131,6 +132,13 @@ def inject_clients():
 
 clients = inject_clients()
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.mount("/", StaticFiles(directory=clients['current_directory'] / "static"), name="static")
 clients['mmrag'].attach_to_app(app, "/chat")
 clients['mmrag'].attach_to_app(app, "/multiindex_chat")


### PR DESCRIPTION
## Summary
- allow cross-origin requests in `src/backend/app.py`
- enable CORS in `legal_research_server.py`
- enable CORS in `legal_nlp_server.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b5773fa0832aa0c1b6b72ca19f01